### PR TITLE
fix: カードをundefinedにした場合のplay-cardをパースして起こるエラーを修正。

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,11 +85,14 @@ class Turn():
                     temp_list[6] = ["R"]
 
             if activity.event == "play-card":
-                played_card = activity.contents["card_play"]
-                temp_list[1] = [self.parse_card(played_card)]
                 player = activity.player
                 index = players.index(player)
-                temp_list[index+2] = [self.parse_card(activity.contents["card_play"])]
+                if not "card_play" in activity.contents:
+                    temp_list[index+2] = ["no card play"]
+                else:
+                    played_card = activity.contents["card_play"]
+                    temp_list[1] = [self.parse_card(played_card)]
+                    temp_list[index+2] = [self.parse_card(activity.contents["card_play"])]
 
             if activity.event == "special-logic":
                 player = activity.player


### PR DESCRIPTION
プレイヤがカード提出に失敗した際、play-cardのパースに失敗してログを表示できなくなる問題を修正しました。

テストに使用したデータです:
[12300052.log](https://github.com/spa15332/log_checker/files/10320479/12300052.log)

改修前は次のようなエラーが発生していました:
[error.log](https://github.com/spa15332/log_checker/files/10320488/error.log)

原因は、プレイヤが{ card_play: undefined }のようなデータを送信すると、log中の `play-card` イベントデータに `card_play` キーが含まれなくなってしまうことだと思われます。

そのため、キーのアクセス前にキーの存在チェックを行い、存在しなければGUIには `no card play` と表示するようにしました。