### PR TITLE
スクロール時のヘッダーの横幅調整

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -23,11 +23,11 @@ h1 {
 }
 
 header {
+    margin: 0 8px 0;
     position: fixed;
     z-index: 999;
     top: 0;
     left: 0;
-    width: 100%;
     padding: 0px 0px;
     background: #FFFFFF;
     box-sizing: border-box;


### PR DESCRIPTION
開発支援ツールの共有ありがとうございます。
大変便利に利用させていただいています。

下スクロールをした際に出てくるヘッダーの横幅が私の環境だとずれていたのでマージンを両側に入れて調整しました。
お時間ありましたら見ていただけますと幸いです。
もし私の環境のせいで、他では問題ないようでしたら無視してください。
どうぞよろしくお願いします。


調整前
![image](https://user-images.githubusercontent.com/106291203/212249927-320c68aa-04ab-4306-af5f-b6a888284405.png)

調整後
![image](https://user-images.githubusercontent.com/106291203/212249986-116f703b-2570-4ad7-9b93-ca9c27280db5.png)
